### PR TITLE
add details on firehose dynamic partitioning config using processors

### DIFF
--- a/doc_source/aws-properties-kinesisfirehose-deliverystream-dynamicpartitioningconfiguration.md
+++ b/doc_source/aws-properties-kinesisfirehose-deliverystream-dynamicpartitioningconfiguration.md
@@ -1,6 +1,6 @@
 # AWS::KinesisFirehose::DeliveryStream DynamicPartitioningConfiguration<a name="aws-properties-kinesisfirehose-deliverystream-dynamicpartitioningconfiguration"></a>
 
-The `DynamicPartitioningConfiguration` property type specifies the configuration of the dynamic partitioning mechanism that creates targeted data sets from the streaming data by partitioning it based on partition keys\.
+The `DynamicPartitioningConfiguration` property type specifies the configuration of the dynamic partitioning mechanism that creates targeted data sets from the streaming data by partitioning it based on partition keys\. Partitioning keys may be applied using a [ProcessingConfiguration](#aws-properties-kinesisfirehose-deliverystream-processingconfiguration.md).
 
 ## Syntax<a name="aws-properties-kinesisfirehose-deliverystream-dynamicpartitioningconfiguration-syntax"></a>
 


### PR DESCRIPTION
*Issue #, if available:* #1259 

*Description of changes:*
Add comment to AWS::KinesisFirehose::DeliveryStream DynamicPartitioningConfiguration providing clarity that ProcessingConfiguration is used in conjunction with DynamicPartitioningConfiguration to actually create dynamic partitioning keys.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
